### PR TITLE
allow admin users, not just owners, to change the texter ui defaultss

### DIFF
--- a/src/server/api/mutations/editOrganization.js
+++ b/src/server/api/mutations/editOrganization.js
@@ -4,7 +4,7 @@ import { r, cacheableData } from "../../models";
 import { getAllowed } from "../organization";
 
 export const editOrganization = async (_, { id, organization }, { user }) => {
-  await accessRequired(user, id, "OWNER", true);
+  await accessRequired(user, id, "ADMIN", true);
   const orgRecord = await cacheableData.organization.load(id);
   const features = getFeatures(orgRecord);
   const changes = {};

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -215,7 +215,7 @@ export const resolvers = {
     textingHoursEnd: organization => organization.texting_hours_end,
     texterUIConfig: async (organization, _, { user }) => {
       try {
-        await accessRequired(user, organization.id, "OWNER");
+        await accessRequired(user, organization.id, "ADMIN");
       } catch (caught) {
         return null;
       }


### PR DESCRIPTION
# Fixes # (issue)

Jira task SPOKE-66: Increase Admin permissions (opt-out message, texting hours, texter UI)

## Description

Gave Admin users permisssion to edit an organization and set the texter UI, something previously restricted to Owners. They already had permission to change the opt-out messsage and texting hours. 

# Checklist:

- [ X] I have manually tested my changes on desktop and mobile
- [ X] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
