### PR TITLE
Rearrange script editor fields SPOKE-74

### DIFF
--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -216,7 +216,7 @@ class ScriptEditor extends React.Component {
     const text = this.state.editorState.getCurrentContent().getPlainText();
     const segmentInfo = getCharCount(replaceEasyGsmWins(text));
     return (
-      <div style="overflow-y: auto">
+      <div>
         <div style={segmentInfo.charCount > 1600 ? { color: "red" } : {}}>
           Total characters: {segmentInfo.charCount}
           {segmentInfo.charCount > 1600 ? (

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -45,7 +45,8 @@ const styles = {
   scriptFieldButtonSection: {
     marginTop: 10,
     padding: 5,
-    overflowY: "scroll !important"
+    maxHeight: "600px",
+    overflowY: "auto"
   }
 };
 

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -44,7 +44,8 @@ const styles = {
   },
   scriptFieldButtonSection: {
     marginTop: 10,
-    padding: 5
+    padding: 5,
+    overflowY: "scroll !important"
   }
 };
 

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -43,7 +43,8 @@ const styles = {
   },
   scriptFieldButtonSection: {
     marginTop: 10,
-    padding: 5
+    padding: 5,
+    overflowY: "scroll"
   }
 };
 

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -19,8 +19,7 @@ const styles = {
     cursor: "text",
     fontSize: 16,
     padding: 5,
-    marginBottom: 10,
-    overflowY: "auto"
+    marginBottom: 10
   },
   button: {
     marginTop: 10,
@@ -217,7 +216,7 @@ class ScriptEditor extends React.Component {
     const text = this.state.editorState.getCurrentContent().getPlainText();
     const segmentInfo = getCharCount(replaceEasyGsmWins(text));
     return (
-      <div>
+      <div style="overflow-y: auto">
         <div style={segmentInfo.charCount > 1600 ? { color: "red" } : {}}>
           Total characters: {segmentInfo.charCount}
           {segmentInfo.charCount > 1600 ? (

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -231,7 +231,6 @@ class ScriptEditor extends React.Component {
             spellCheck
           />
         </div>
-        {this.renderCustomFields()}
         <div>
           Estimated{" "}
           <Link
@@ -247,6 +246,7 @@ class ScriptEditor extends React.Component {
             segmentInfo.charCount}
           <br />
         </div>
+        {this.renderCustomFields()}
       </div>
     );
   }

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -18,7 +18,9 @@ const styles = {
     border: "1px solid #ddd",
     cursor: "text",
     fontSize: 16,
-    padding: 5
+    padding: 5,
+    marginBottom: 10,
+    overflowY: "auto"
   },
   button: {
     marginTop: 10,
@@ -43,8 +45,7 @@ const styles = {
   },
   scriptFieldButtonSection: {
     marginTop: 10,
-    padding: 5,
-    overflowY: "scroll"
+    padding: 5
   }
 };
 


### PR DESCRIPTION
# Fixes # (issue)
Fixes SPOKE-74

This moves the segment count above the fields so that it's always visible.

The scrolling issue is partially mitigated here. It definitely seems like a Hard(tm) problem that got punted. Anyways, this shoudl alleviate some of the pain points.

## Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change, and any blockers that make your change a WIP_

# Checklist:

- [ x] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
